### PR TITLE
Browserify plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Read Mark Dalgleish's excellent ["End of Global CSS"](https://medium.com/seek-ui
 
 First install the package: `npm install --save css-modulesify`
 
-Then you can use it as a browserify plugin, eg: `browserify -p [ css-modulesify --css dist/main.css ] example/index.js`
+Then you can use it as a browserify plugin, eg: `browserify -p [ css-modulesify -o dist/main.css ] example/index.js`
 
 Inside `example/index.js` you can now load css into your scripts.  When you do `var box1 = require('./box1.css')`, `box1` will be an object to lookup the localized classname for one of the selectors in that file.
 
@@ -25,7 +25,7 @@ var styles = require('./styles.css');
 var div = `<div class="${styles.inner}">...</div>`;
 ```
 
-The generated css will contain locally-scoped versions of any css you have `require`'d, and will be written out to the file you specify in the `--css` option.
+The generated css will contain locally-scoped versions of any css you have `require`'d, and will be written out to the file you specify in the `--output` or `-o` option.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Read Mark Dalgleish's excellent ["End of Global CSS"](https://medium.com/seek-ui
 
 First install the package: `npm install --save css-modulesify`
 
-Then you can use it as a browserify transform, eg: `browserify -t css-modulesify example/index.js`
+Then you can use it as a browserify plugin, eg: `browserify -p [ css-modulesify --css dist/main.css ] example/index.js`
 
 Inside `example/index.js` you can now load css into your scripts.  When you do `var box1 = require('./box1.css')`, `box1` will be an object to lookup the localized classname for one of the selectors in that file.
 
@@ -25,14 +25,11 @@ var styles = require('./styles.css');
 var div = `<div class="${styles.inner}">...</div>`;
 ```
 
-To add the css to the html page there are 2 easy options:
-
-- add the css to the DOM at runtime (good for component-based css): `require('insert-css')(require('./styles.css'))`
-- export a static css file at build-time: `browserify -t css-modulesify example/export-css.js | node > bundle.css`
+The generated css will contain locally-scoped versions of any css you have `require`'d, and will be written out to the file you specify in the `--css` option.
 
 ## Example
 
-An example implementaion can be found [here](https://github.com/css-modules/browserify-demo).
+An example implementation can be found [here](https://github.com/css-modules/browserify-demo).
 
 ## Licence
 

--- a/index.js
+++ b/index.js
@@ -1,26 +1,61 @@
+var fs = require('fs');
 var path = require('path');
 var through = require('through');
 var FileSystemLoader = require('css-modules-loader-core/lib/file-system-loader');
 
 var cssExt = /\.css$/;
-module.exports = function (filename) {
-  // only handle .css files
-  if (!cssExt.test(filename)) {
-    return through();
+module.exports = function (browserify, options) {
+  options = options || {};
+
+  var cssOutFilename = options.css;
+  if (!cssOutFilename) {
+    throw new Error('css-modulesify needs the --css option (path to output css file)');
   }
 
-  return through(function noop () {}, function end () {
-    var self = this;
+  var cssOut = through();
+  cssOut.pipe(fs.createWriteStream(cssOutFilename));
 
-    var loader = new FileSystemLoader(path.dirname(filename));
-    loader.fetch(path.basename(filename), '/').then(function (tokens) {
-      var output = "module.exports = " + JSON.stringify(tokens) +
-          "\nmodule.exports.toString = function () { return " + JSON.stringify(loader.finalSource) + "; }";
+  var filenames = [];
+  browserify.transform(function transform (filename) {
+    // only handle .css files
+    if (!cssExt.test(filename)) {
+      return through();
+    }
 
-      self.queue(output);
-      self.queue(null);
-    }, function (err) {
-      console.error(err);
+    // collect visited filenames
+    filenames.push(filename);
+
+    return through(function noop () {}, function end () {
+      var self = this;
+
+      var loader = new FileSystemLoader(path.dirname(filename));
+      loader.fetch(path.basename(filename), '/').then(function (tokens) {
+        var output = "module.exports = " + JSON.stringify(tokens);
+
+        cssOut.queue(loader.finalSource);
+
+        self.queue(output);
+        self.queue(null);
+      }, function (err) {
+        console.error(err);
+      });
     });
   });
+
+  // wrap the `bundle` function
+  var bundle = browserify.bundle;
+  browserify.bundle = function (opts, cb) {
+
+    // call the original
+    var stream = bundle.apply(browserify, arguments);
+
+    // close the css stream
+    stream.on('end', function () {
+      cssOut.queue(null);
+    });
+
+    return stream;
+  };
+
+  return browserify;
 };

--- a/index.js
+++ b/index.js
@@ -7,9 +7,9 @@ var cssExt = /\.css$/;
 module.exports = function (browserify, options) {
   options = options || {};
 
-  var cssOutFilename = options.css;
+  var cssOutFilename = options.output || options.o;
   if (!cssOutFilename) {
-    throw new Error('css-modulesify needs the --css option (path to output css file)');
+    throw new Error('css-modulesify needs the --output / -o option (path to output css file)');
   }
 
   var cssOut = through();

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "keywords": [
     "browserify-transform",
+    "browserify-plugin",
     "css-modules",
     "browserify",
     "css"


### PR DESCRIPTION
@joshgillies @rtsao please let me know if you think this should be approached differently, or have other ideas.

Notable changes:

- `--css` plugin option is required (destination css file)
- I've removed the `.toString` export, since css will be written to a file instead of being included in the js bundle (for consistency with the webpack implementation).

Once we've done some more testing on this we'll merge and then will need to upgrade https://github.com/css-modules/browserify-demo