### PR TITLE
append a hash of the css source to scoped classnames

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var stringHash = require('string-hash');
   Custom `generateScopedName` function for `postcss-modules-scope`.
   Appends a hash of the css source.
 */
-function createNameFunc (plugin) {
+function createScopedNameFunc (plugin) {
   var orig = plugin.generateScopedName;
   return function (name, path, css) {
     var hash = stringHash(css).toString(36).substr(0, 5);

--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ module.exports = function (browserify, options) {
 
       // custom scoped name generation
       if (name === 'postcss-modules-scope') {
+        options[name] = options[name] || {};
         options[name].generateScopedName = createScopedNameFunc(plugin);
       }
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "css-modules-loader-core": "0.0.10",
     "object-assign": "^3.0.0",
+    "string-hash": "^1.1.0",
     "through": "^2.3.7"
   },
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A browserify transform to load CSS Modules",
   "main": "index.js",
   "dependencies": {
-    "css-modules-loader-core": "0.0.10",
+    "css-modules-loader-core": "0.0.11",
     "object-assign": "^3.0.0",
     "string-hash": "^1.1.0",
     "through": "^2.3.7"


### PR DESCRIPTION
This fixes the issue noted in #15.  Depends on an update to `postcss-modules-scope` (but it might make more sense for this to become the default behavior).