### PR TITLE
fix: already setup plugins detected correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,8 +24,8 @@ module.exports = function (browserify, options) {
     }
 
     plugins = plugins.map(function requirePlugin (name) {
-      // assume objects are already required plugins
-      if (typeof name === 'object') {
+      // assume functions are already required plugins
+      if (typeof name === 'function') {
         return name;
       }
 


### PR DESCRIPTION
Turns out, post-css plugins are functions, not objects when already
setup.