### PR TITLE
add: plugin paths now found relative to cwd

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function (browserify, options) {
         return name;
       }
 
-      var plugin = require(name);
+      var plugin = require(require.resolve(name));
 
       if (name in options) {
         plugin = plugin(options[name]);


### PR DESCRIPTION
This allows css-moduleify to be installed in a different directory than
the post-css plugins and still allow them to be found.