### PR TITLE
Fix race condition

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,22 +108,20 @@ module.exports = function (browserify, options) {
 
   // wrap the `bundle` function
   var bundle = browserify.bundle;
-  browserify.bundle = function (opts, cb) {
+  browserify.bundle = function (cb) {
     // reset the `tokensByFile` cache
     tokensByFile = {};
 
     // call the original
-    var stream = bundle.apply(browserify, arguments);
-
-    // close the css stream
-    stream.on('end', function () {
+    var stream = bundle.call(browserify, function () {
       // Combine the collected sources into a single CSS file
       var css = Object.keys(sourceByFile).map(function(file) {
         return sourceByFile[file];
       }).join('\n');
+      var args = arguments;
 
-      fs.writeFile(cssOutFilename, css, function(err) {
-        if (err) console.error(err);
+      fs.writeFile(cssOutFilename, css, function () {
+        if (typeof cb === 'function') cb.apply(null, args);
       });
     });
 


### PR DESCRIPTION
Two things:

1) Reverting back to browserify's original `bundle` method. This method is only intended to take a singular argument (a callback in this case).
2) `stream.on('end', function () {})` creates a race condition. Using a callback in the bundle method instead to resolve this.