### PR TITLE
Don't define transform as global

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,9 +107,7 @@ module.exports = function (browserify, options) {
     });
   }
 
-  browserify.transform(transform, {
-    global: true
-  });
+  browserify.transform(transform);
 
   // wrap the `bundle` function
   var bundle = browserify.bundle;


### PR DESCRIPTION
Global transforms run after all other transforms, which means that all other transforms will try to process the CSS file. 

This is bad for many transforms that are like e.g. brfs, which don't check whether the file is valid JS before proceeding to try and parse it (with acorn)

This patch makes https://github.com/css-modules/browserify-demo/ work