### PR TITLE
Update README to reflect change from transform to plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/css-modules/css-modulesify.svg?branch=master)](https://travis-ci.org/css-modules/css-modulesify)
 
-A browserify transform to load [CSS Modules].
+A browserify plugin to load [CSS Modules].
 
 [CSS Modules]: https://github.com/css-modules/css-modules
 


### PR DESCRIPTION
Looks like most cases of the word "transform" were changed to "plugin" upon merging #10 back in June, but the top-level description (not reflected in this PR, will have to be manually changed by project owner) and the first description in the README still list it as "transform".