### PR TITLE
Ensure caches are persisted

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,22 @@ function normalizeManifestPaths (tokensByFile, rootDir) {
 }
 
 var cssExt = /\.css$/;
+
+// caches
+//
+// persist these for as long as the process is running. #32
+
+// keep track of css files visited
+var filenames = [];
+
+// keep track of all tokens so we can avoid duplicates
+var tokensByFile = {};
+
+// keep track of all source files for later builds: when
+// using watchify, not all files will be caught on subsequent
+// bundles
+var sourceByFile = {};
+
 module.exports = function (browserify, options) {
   options = options || {};
 
@@ -90,17 +106,6 @@ module.exports = function (browserify, options) {
 
     return plugin;
   });
-
-  // keep track of css files visited
-  var filenames = [];
-
-  // keep track of all tokens so we can avoid duplicates
-  var tokensByFile = {};
-
-  // keep track of all source files for later builds: when
-  // using watchify, not all files will be caught on subsequent
-  // bundles
-  var sourceByFile = {};
 
   function transform (filename) {
     // only handle .css files

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "browserify": "^11.0.1",
     "proxyquire": "^1.6.0",
+    "rebundler": "^0.2.0",
     "tape": "^4.0.1"
   },
   "scripts": {

--- a/tests/cache.js
+++ b/tests/cache.js
@@ -1,0 +1,49 @@
+var tape = require('tape');
+
+var browserify = require('browserify');
+var proxyquire = require('proxyquire');
+var fs = require('fs');
+var path = require('path');
+var rebundler = require('rebundler');
+
+var casesDir = path.join(__dirname, 'cases');
+var simpleCaseDir = path.join(casesDir, 'simple');
+var cssOutFilename = 'out.css';
+
+tape('multiple builds', function (t) {
+  var fakeFs = {
+    writeFile: function (filename, content, cb) {
+      var expected = fs.readFileSync(path.join(simpleCaseDir, 'expected.css'), 'utf8');
+
+      t.equal(filename, cssOutFilename, 'correct output filename');
+      t.equal(content, expected, 'output matches expected');
+      cb();
+    }
+  };
+
+  var cssModulesify = proxyquire('../', {
+    fs: fakeFs
+  });
+
+  var getBundler = rebundler(function (cache, packageCache) {
+    return browserify(path.join(simpleCaseDir, 'main.js'), {
+      cache: cache
+    , packageCache: packageCache
+    , fullPaths: true
+    })
+      .plugin(cssModulesify, {
+        rootDir: path.join(simpleCaseDir)
+        , output: cssOutFilename
+      });
+  });
+
+  getBundler().bundle(function (err) {
+    t.error(err, 'initial bundle without a cache does not error');
+
+    getBundler().bundle(function (err2) {
+      t.error(err2, 'second pass bundle with a cache does not error');
+
+      t.end();
+    });
+  });
+});


### PR DESCRIPTION
Previously, the caches were re-initialized on every plugin initialization.
This caused an incompatibility with other tools like rebundler or
persistify.

This change keeps the original intent of creating caches when the plugin is
initialized, but ensures the process keeps the caches instead of the plugin
instance itself. It’s not really possible to have a cache conflict since
they’re keyed by file.

Fixes #32