### PR TITLE
Emit error on stream.

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ module.exports = function (browserify, options) {
         self.queue(output);
         self.queue(null);
       }, function (err) {
-        browserify.emit('error', err);
+        self.emit('error', err);
       });
     });
   }


### PR DESCRIPTION
I was having this issue when I've miss-typed a class name and `css-modulesify` would silently stop working when using `watchify`.

My `package.json` scripts object:

```json
"scripts": {
    "start": "http-server -s & npm run watch-coffee",
    "build": "npm run build-coffee",
    "watch-coffee": "watchify -v -p [ css-modulesify -o dist/starterkit.css ] -t [ hbsfy -e thtml ] -t coffeeify starterkit/src/app.coffee -o dist/starterkit.js",
    "build-coffee": "browserify -p [ css-modulesify -o dist/starterkit.css ] -t [ hbsfy -e thtml ] -t coffeeify starterkit/src/app.coffee -o dist/starterkit.js"
  },
```

With this change error will emit back to watchify and recover will work as well.