### PR TITLE
fix a race-condition with tokensByFile

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,12 +118,9 @@ module.exports = function (browserify, options) {
     // collect visited filenames
     filenames.push(filename);
 
+    var loader = new FileSystemLoader(rootDir, plugins);
     return through(function noop () {}, function end () {
       var self = this;
-      var loader = new FileSystemLoader(rootDir, plugins);
-
-      // pre-populate the loader's tokensByFile
-      loader.tokensByFile = tokensByFile;
 
       loader.fetch(path.relative(rootDir, filename), '/').then(function (tokens) {
         var output = 'module.exports = ' + JSON.stringify(tokens);


### PR DESCRIPTION
Because we’re setting `tokensByFile` before and after an async action,
and many of these actions can happen at the same time, there’s a race
condition where the incorrect `tokensByFile` can be set.

This accomplishes the same desire for caching by just keeping the loader
for every file since the loader already caches `tokensByFile`, and
prevents the race condition.