### PR TITLE
Update "css-modules-loader-core" to "^1.0.0" on #47: values-support

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A browserify transform to load CSS Modules",
   "main": "index.js",
   "dependencies": {
-    "css-modules-loader-core": "^1.0.0-beta4",
+    "css-modules-loader-core": "^1.0.0",
     "promise-polyfill": "^2.1.0",
     "object-assign": "^3.0.0",
     "string-hash": "^1.1.0",


### PR DESCRIPTION
Just tying up a minor detail before a potential release.

Also, so I can `"css-modulesify": "git://github.com/bcomnes/css-modulesify.git#values-support"` this afternoon prior to release.

UPDATE:  Seems to be working really well from some light use this afternoon.