### PR TITLE
Fix bug where browserify didn't emit error

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,7 +190,7 @@ module.exports = function (browserify, options) {
       return callback();
     }).catch(function (err) {
       self.push('console.error("' + err + '");');
-      browserify.emit('error', err);
+      self.emit('error', err);
       return callback();
     });
   };


### PR DESCRIPTION
There were no errors being thrown in the console when bundling with browserify which broke the build process and prevented watchify from rebuilding.