### PR TITLE
load plugins by name only if a string is used

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,8 +117,8 @@ module.exports = function (browserify, options) {
 
   // load plugins by name (if a string is used)
   plugins = plugins.map(function requirePlugin (name) {
-    // assume functions are already required plugins
-    if (typeof name === 'function') {
+    // assume not strings are already required plugins
+    if (typeof name !== 'string') {
       return name;
     }
 


### PR DESCRIPTION
Add ability to load already configured plugins like cssnext(options), which returns processor object, not a function.