### PR TITLE
Pass correct `from` arg for resolved files

### DIFF
--- a/file-system-loader.js
+++ b/file-system-loader.js
@@ -72,6 +72,8 @@ var FileSystemLoader = (function () {
         if (newPath[0] !== '.' && newPath[0] !== '/') {
           try {
             fileRelativePath = nodeResolve.sync(newPath, { basedir: rootRelativeDir });
+            // in this case we need to actualize rootRelativePath too
+            rootRelativePath = _path2['default'].relative(_this.root, fileRelativePath);
           } catch (e) {}
         }
 


### PR DESCRIPTION
Pass correct 'from' parameter to postcss for files which resolved via `nodeResolve.sync`

Incorrect source path leads to wrong names which postcss-plugin-scope generates for example