### PR TITLE
Fix: correctly emit 'css stream'

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ b.plugin(require('css-modulesify'), {
 });
 
 var bundle = b.bundle()
-bundle.on('css stream', function (css) {
+b.on('css stream', function (css) {
   css.pipe(fs.createWriteStream('mycss.css'));
 });
 ```
@@ -70,7 +70,7 @@ bundle.on('css stream', function (css) {
 - `generateScopedName`: (API only) a function to override the default behaviour of creating locally scoped classnames.
 
 ### Events
-- `b.bundle().on('css stream', callback)` The callback is called with a readable stream containing the compiled CSS. You can write this to a file.
+- `b.on('css stream', callback)` The callback is called with a readable stream containing the compiled CSS. You can write this to a file.
 
 ## Using CSS Modules on the backend
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ b.on('css stream', function (css) {
 - `rootDir`: absolute path to your project's root directory. This is optional but providing it will result in better generated classnames.
 - `output`: path to write the generated css. If not provided, you'll need to listen to the `'css stream'` event on the bundle to get the output.
 - `jsonOutput`: optional path to write a json manifest of classnames.
-- `use`: optional array of postcss plugins (by default we use the css-modules core plugins).
+- `use`: optional array of postcss plugins (by default we use the css-modules core plugins). NOTE: it's safer to use `after`
+- `after`:  optional array of postcss plugins to run after the required css-modules core plugins are run.
 - `generateScopedName`: (API only) a function to override the default behaviour of creating locally scoped classnames.
 
 ### Events

--- a/index.js
+++ b/index.js
@@ -184,7 +184,7 @@ module.exports = function (browserify, options) {
     compiledCssStream = new ReadableStream();
     compiledCssStream._read = function () {};
 
-    bundle.emit('css stream', compiledCssStream);
+    browserify.emit('css stream', compiledCssStream);
 
     bundle.on('end', function () {
       // Combine the collected sources into a single CSS file


### PR DESCRIPTION
Previously, the event would only get emitted on the first run. This is a
problem for watchify-like environments.

Note: this is a breaking change.