### PR TITLE
Emit on pack stage of pipeline

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ module.exports = function (browserify, options) {
       return name;
     }
 
-    var plugin = require(require.resolve(name));
+    var plugin = module.parent.require(name);
 
     // custom scoped name generation
     if (name === 'postcss-modules-scope') {


### PR DESCRIPTION
This PR moves the CSS and JSON emitting to the `pack` stage of the Browserify pipeline, similar to how `factor-bundle` works. This change enables other plugins to listen to the `css stream` event and react within the Browserify pipeline as well.

This PR also uses `module.parent.require` to pull in plugins that were given by string. This has no effect in normal situations, but allows this library to be linked in via `npm link`.