### PR TITLE
allow global option via command line

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ module.exports = function (browserify, options) {
   if (!rootDir) { rootDir = process.cwd(); }
 
   var transformOpts = {};
-  if (options.global) {
+  if (options.global || options.g) {
     transformOpts.global = true;
   }
 


### PR DESCRIPTION
There's currently no way to pass in the `global` option via the `browserify` command line. Ie:

``` bash
$ browserify -p [ css-modulesify -g -o bundle.css ] index.js -o bundle.js
```

Where `index.js` is a file that requires a CSS module from within `node_modules`. Eg:

``` js
const maxWidths = require('tachyons-max-widths');
```

This PR fixes this issue.