### PR TITLE
Do not use global cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ b.on('css stream', function (css) {
 - `generateScopedName`: (API only) a function to override the default behaviour of creating locally scoped classnames.
 - `global`: optional boolean. Set to `true` if you want `css-modulesify` to apply to `node_modules` as well as local files. You can read more about it in the [browserify docs](https://github.com/substack/node-browserify/#btransformtr-opts).
 - `filePattern`: optional regular expression string to specify css file names. (default: `\.css$`)
+- `cache`: optional object to persist cache between runs.
 
 ### Events
 - `b.on('css stream', callback)` The callback is called with a readable stream containing the compiled CSS. You can write this to a file.

--- a/cmify.js
+++ b/cmify.js
@@ -3,7 +3,7 @@ var path = require("path");
 var util = require("util");
 
 util.inherits(Cmify, stream.Transform);
-function Cmify(filename, opts) {
+function Cmify (filename, opts) {
   if (!(this instanceof Cmify)) {
     return new Cmify(filename, opts);
   }
@@ -11,24 +11,24 @@ function Cmify(filename, opts) {
   stream.Transform.call(this);
 
   this.cssFilePattern = new RegExp(opts.cssFilePattern || '\.css$');
-  this._data = "";
+  this._data = '';
   this._filename = filename;
   this._cssOutFilename = opts.cssOutFilename;
 }
 
 Cmify.prototype.isCssFile = function (filename) {
-  return this.cssFilePattern.test(filename)
-}
+  return this.cssFilePattern.test(filename);
+};
 
 Cmify.prototype._transform = function (buf, enc, callback) {
   // only handle .css files
   if (!this.isCssFile(this._filename)) {
-    this.push(buf)
-    return callback()
+    this.push(buf);
+    return callback();
   }
 
-  this._data += buf
-  callback()
+  this._data += buf;
+  callback();
 };
 
-module.exports = Cmify
+module.exports = Cmify;

--- a/cmify.js
+++ b/cmify.js
@@ -1,6 +1,7 @@
-var stream = require("stream");
-var path = require("path");
-var util = require("util");
+var stream = require('stream');
+var util = require('util');
+var assign = require('object-assign');
+var path = require('path');
 
 util.inherits(Cmify, stream.Transform);
 function Cmify (filename, opts) {
@@ -14,6 +15,10 @@ function Cmify (filename, opts) {
   this._data = '';
   this._filename = filename;
   this._cssOutFilename = opts.cssOutFilename;
+  this._loader = opts.loader;
+  this._tokensByFile = opts.tokensByFile;
+  this._rootDir = opts.rootDir;
+  opts.cssFiles.push(filename);
 }
 
 Cmify.prototype.isCssFile = function (filename) {
@@ -29,6 +34,54 @@ Cmify.prototype._transform = function (buf, enc, callback) {
 
   this._data += buf;
   callback();
+};
+
+Cmify.prototype._flush = function (callback) {
+  var self = this;
+  var filename = this._filename;
+
+  // only handle .css files
+  if (!this.isCssFile(filename)) { return callback(); }
+
+  // grab the correct loader
+  var loader = this._loader;
+  var tokensByFile = this._tokensByFile;
+
+  // convert css to js before pushing
+  // reset the `tokensByFile` state
+  var relFilename = path.relative(this._rootDir, filename);
+  tokensByFile[filename] = loader.tokensByFile[filename] = null;
+
+  loader.fetch(relFilename, '/').then(function (tokens) {
+    var deps = loader.deps.dependenciesOf(filename);
+    var output = deps.map(function (f) {
+      return 'require("' + f + '")';
+    });
+    output.push('module.exports = ' + JSON.stringify(tokens));
+
+    var isValid = true;
+    var isUndefined = /\bundefined\b/;
+    Object.keys(tokens).forEach(function (k) {
+      if (isUndefined.test(tokens[k])) {
+        isValid = false;
+      }
+    });
+
+    if (!isValid) {
+      var err = 'Composition in ' + filename + ' contains an undefined reference';
+      console.error(err);
+      output.push('console.error("' + err + '");');
+    }
+
+    assign(tokensByFile, loader.tokensByFile);
+
+    self.push(output.join('\n'));
+    return callback();
+  }).catch(function (err) {
+    self.push('console.error("' + err + '");');
+    self.emit('error', err);
+    return callback();
+  });
 };
 
 module.exports = Cmify;

--- a/tests/cache.js
+++ b/tests/cache.js
@@ -25,6 +25,7 @@ tape('multiple builds', function (t) {
     fs: fakeFs
   });
 
+  var cssModulesifyCache = {};
   var getBundler = rebundler(function (cache, packageCache) {
     return browserify(path.join(simpleCaseDir, 'main.js'), {
       cache: cache
@@ -34,6 +35,7 @@ tape('multiple builds', function (t) {
       .plugin(cssModulesify, {
         rootDir: path.join(simpleCaseDir)
         , output: cssOutFilename
+        , cache: cssModulesifyCache
       });
   });
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -11,13 +11,13 @@ var cssOutFilename = 'out.css';
 function runTestCase (dir) {
   tape('case: ' + dir, function (t) {
     // load (optional) custom setup for this testcase
-    var customPath = path.join(casesDir, dir, 'custom.js')
-    var customOpts
+    var customPath = path.join(casesDir, dir, 'custom.js');
+    var customOpts;
     try {
-      fs.accessSync(customPath)
-      customOpts = require(customPath)
+      fs.accessSync(customPath);
+      customOpts = require(customPath);
     } catch (e) {
-      customOpts = {}
+      customOpts = {};
     }
 
     var fakeFs = {


### PR DESCRIPTION
Currently when running css-modulesify first time passed postcss plugins are cached in loader and the subsequent runs in the same process but with different set of plugins result in using cached plugins. The only workaround is to reload module with `delete require.cache[require.resolve('css-modulesify')];`.

This is happening because of persisting cache globally that was made because `cache` option passed to browserify [is forwarded](https://github.com/substack/node-browserify/issues/1004#issuecomment-65747255) to [module-deps](https://github.com/substack/module-deps/blob/master/index.js) where it's filled with record for each module (record for css module contains javascript code generated with `cmify.js`). So without persisting tokens and loader between runs when using browserify `cache` option (e.g. with [rebundler](https://github.com/bjoerge/rebundler)) if css file is not changed then file record is not removed from browserify cache and module-deps does not reapply transformations and css (which is "side-effect" of transformations) is not outputted which was the #32 issue reported by @joeybaker and was fixed by him in #40 by introducing global cache.

Persisting cache globally results in issue like I described above and I suggest to use `cache` option that can be reused between runs. So it makes css-modulesify stateless again but allows to persist cache e.g. for using with rebundler.
