### PR TITLE
Sort output by filename for more determinism.

### DIFF
--- a/file-system-loader.js
+++ b/file-system-loader.js
@@ -125,7 +125,7 @@ var FileSystemLoader = (function () {
       var sources = this.sources;
       var written = {};
 
-      return this.deps.overallOrder().map(function (filename) {
+      return this.deps.overallOrder().slice().sort().map(function (filename) {
         if (written[filename] === true) {
           return null;
         }


### PR DESCRIPTION
Currently the order seems arbitrary, resulting in a non-reproducable build output.
Note this only addresses one source of non-determinism, there may be more.

In case it looks dangerous to you, notice that this only sorts the roots of the dependency graph, so it does not introduce out-of-order dependencies.